### PR TITLE
Update FaunaDB link styling

### DIFF
--- a/src/components/GettingStarted.js
+++ b/src/components/GettingStarted.js
@@ -164,7 +164,7 @@ export function GettingStarted() {
             profiles, shopping cart data, game levels, or other dynamic data.
             Get started for free with{' '}
             <Link
-              variant="ghost"
+              color="pink"
               title="FaunaDB Serverless GraphQL"
               href="https://fauna.com/"
             >


### PR DESCRIPTION
<img width="504" alt="Screenshot 2020-05-15 at 00 28 37" src="https://user-images.githubusercontent.com/4006802/81992235-54542f80-9643-11ea-9dd6-fb5357af8b03.png">

Not sure if this was done intentionally or not, but to me it was not clear that "FaunaDB Serverless GraphQL" was a link (see the screenshot above). This PR makes the FaunaDB link consistent with the links in the paragraph above.