### PR TITLE
Add Kontent to the headless CMS list

### DIFF
--- a/src/components/GettingStarted.js
+++ b/src/components/GettingStarted.js
@@ -261,6 +261,11 @@ export function GettingStarted() {
               Sanity.io
             </Link>
           </Li>
+          <Li>
+            <Link variant="ghost" title="Kontent" href="https://www.kontent.ai/">
+              Kontent
+            </Link>
+          </Li>
         </Ul>
         <Box mt={[4, 5]}>
           <ReadMore href="https://headlesscms.org/">


### PR DESCRIPTION
Hey @peduarte,

would you be open in adding [Kontent](https://kontent.ai) to the list of headless CMS?

I have seen you linked @ondrabus's pull request with our JAMStack report recently, so I think it would be a nice enhancement.